### PR TITLE
fix: add opacity for mobile split hero

### DIFF
--- a/app/Blocks/SplitHeroBlock.php
+++ b/app/Blocks/SplitHeroBlock.php
@@ -117,6 +117,8 @@ class SplitHeroBlock extends Block
             'image' => $this->getImage(),
             'video' => $this->getVideo(),
             'lottie' => $this->getLottie(),
+            'overlay_color' => $this->getOverlayColor(),
+            'overlay_opacity' => $this->getOverlayOpacity(),
             'compact' => $this->getCompact(),
         ];
     }
@@ -167,6 +169,29 @@ class SplitHeroBlock extends Block
                 'placement' => 'top',
             ])
             ->addPartial(MediaComponent::class)
+
+            ->addTab('Background Overlay', [
+                'placement' => 'top',
+            ])
+            ->addColorPicker('overlay_color', [
+                'label' => 'Overlay Color (Mobile only)',
+                'default_value' => '#000000',
+                'wrapper' => [
+                    'width' => '25',
+                ],
+            ])
+            ->addRange('overlay_opacity', [
+                'label' => 'Overlay Opacity (Mobile only)',
+                'instructions' => 'Controls the opacity of the overlay.',
+                'default_value' => 50,
+                'min' => 0,
+                'max' => 100,
+                'step' => 5,
+                'append' => '%',
+                'wrapper' => [
+                    'width' => '25',
+                ],
+            ])
 
             ->addTab('Settings', [
                 'placement' => 'top',
@@ -259,6 +284,31 @@ class SplitHeroBlock extends Block
     public function getLottie()
     {
         return get_field('lottie');
+    }
+
+    /**
+     * Get the overlay color field.
+     *
+     * @return string|null
+     */
+    public function getOverlayColor()
+    {
+        return get_field('overlay_color') ?: null;
+    }
+
+    /**
+     * Get the overlay opacity field (normalized to 0–1).
+     *
+     * @return float
+     */
+    public function getOverlayOpacity()
+    {
+        $opacity = get_field('overlay_opacity');
+        if ($opacity === null) {
+            return 0;
+        }
+
+        return max(0, min(100, intval($opacity)));
     }
 
     /**

--- a/resources/views/blocks/split-hero.blade.php
+++ b/resources/views/blocks/split-hero.blade.php
@@ -1,7 +1,8 @@
 @php
   /**
    * Split Hero
-   * 50/50 split layout with content and media side by side
+   * 50/50 split layout with content and media side by side (desktop)
+   * Background image layout on mobile
    */
   use App\Enums\HeadingTag;
   use App\Enums\HeadingSize;
@@ -40,8 +41,21 @@
 @endphp
 
 <x-section :size="SectionSize::NONE" classes="bg-primary-dark relative w-full {{ $heightClass }} overflow-hidden {{ $block->classes ?? '' }}">
-  {{-- Media Section (Right) - Positioned absolutely to extend to screen edge --}}
-  <div class="absolute inset-y-0 right-0 w-1/2 lg:w-1/2 overflow-hidden">
+  
+  {{-- Background Image --}}
+  @if($media_type === 'image' && !empty($media_url))
+    <div class="absolute inset-0 lg:hidden">
+      <img 
+        src="{{ $media_url }}" 
+        alt="{{ $title ?? 'Split Hero background' }}"
+        class="w-full h-full object-cover"
+      />
+    </div>
+    <div class="absolute inset-0 lg:hidden pointer-events-none" style="background-color: {{ $overlay_color }}; opacity: {{ ($overlay_opacity ?? 50) / 100 }};"></div>
+  @endif
+
+  {{-- Media Section (Right) - Desktop only --}}
+  <div class="absolute inset-y-0 right-0 w-1/2 overflow-hidden hidden lg:block">
     @if(!empty($media_url))
       <x-media
         :mediaType="$media_type"
@@ -56,10 +70,10 @@
     @endif
   </div>
 
-  {{-- Content Section (Left) - Constrained by container --}}
-  <x-container classes="h-full">
+  {{-- Content Section --}}
+  <x-container classes="h-full relative z-10">
     <div class="grid grid-cols-1 lg:grid-cols-2 h-full">
-      <div class="flex items-center justify-center px-6 py-20 lg:py-24 z-20 relative">
+      <div class="flex items-center justify-center px-6 py-20 lg:py-24">
         <x-flex direction="col" class="max-w-2xl">
           {{-- Eyebrow --}}
           @if ($eyebrow)
@@ -117,7 +131,7 @@
           @endif
         </x-flex>
       </div>
-      {{-- Empty second column to maintain grid spacing --}}
+      {{-- Empty second column to maintain grid spacing on desktop --}}
       <div class="hidden lg:block"></div>
     </div>
   </x-container>


### PR DESCRIPTION
<img width="643" height="846" alt="image" src="https://github.com/user-attachments/assets/7e51e806-efaf-4a15-ac66-8cad7e8172bd" />
