### PR TITLE
fix: testimonials, logo cut off issue

### DIFF
--- a/resources/views/components/testimonial-card-right-logo.blade.php
+++ b/resources/views/components/testimonial-card-right-logo.blade.php
@@ -118,14 +118,14 @@
           @if($websiteUrl)
             <a href="{{ $websiteUrl }}" target="_blank" rel="noopener">
               <img
-                src="{{ $companyLogo['sizes']['thumbnail'] ?? $companyLogo['url'] }}"
+                src="{{ $companyLogo['sizes']['full'] ?? $companyLogo['url'] }}"
                 alt="{{ $companyName }} logo"
                 class="h-30 lg:h-64 w-auto max-w-full object-contain"
               >
             </a>
           @else
             <img
-              src="{{ $companyLogo['sizes']['thumbnail'] ?? $companyLogo['url'] }}"
+              src="{{ $companyLogo['sizes']['full'] ?? $companyLogo['url'] }}"
               alt="{{ $companyName }} logo"
               class="h-30 lg:h-64 w-auto max-w-full object-contain"
             >

--- a/resources/views/components/testimonial-card-right-quote.blade.php
+++ b/resources/views/components/testimonial-card-right-quote.blade.php
@@ -59,14 +59,14 @@
         @if($websiteUrl)
           <a href="{{ $websiteUrl }}" target="_blank" rel="noopener">
             <img
-              src="{{ $companyLogo['sizes']['thumbnail'] ?? $companyLogo['url'] }}"
+              src="{{ $companyLogo['sizes']['full'] ?? $companyLogo['url'] }}"
               alt="{{ $companyName }} logo"
               class="h-12 w-auto max-w-full object-contain"
             >
           </a>
         @else
           <img
-            src="{{ $companyLogo['sizes']['thumbnail'] ?? $companyLogo['url'] }}"
+            src="{{ $companyLogo['sizes']['full'] ?? $companyLogo['url'] }}"
             alt="{{ $companyName }} logo"
             class="h-12 w-auto max-w-full object-contain"
           >


### PR DESCRIPTION
Solving [ticket](https://madestudios.monday.com/boards/10001936946/pulses/18258009438/posts/4607531215?reply=reply-4626995342): "When we uploaded some new case studies, looks like a lot of the logos ended up getting cut off."

issue: 
<img width="469" height="366" alt="image" src="https://github.com/user-attachments/assets/eb50d245-2884-49ad-b050-4c9a3797e06f" />
solution:
<img width="584" height="430" alt="Screenshot 2025-10-30 at 1 53 48 PM" src="https://github.com/user-attachments/assets/a3343722-bbab-4266-83d2-cb4053e77cd1" />
